### PR TITLE
Intergration spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ To run tests, run the following command:
 - GitHub: [@Obimbo07](https://github.com/Obimbo07/)
 - LinkedIn: [Austin Obimbo](https://www.linkedin.com/in/austin-obimbo/)
 - WellFounded: [Austin Obimbo](https://wellfound.com/u/austin-obimbo)
+
+👤 **Afimia Fidelis Izebiafe**
+
+- GitHub: [@Izebiafe](https://github.com/Izebiafe)
+- Twitter: [@Izebiafe](https://twitter.com/Izebiafe)
+- LinkedIn: [Izebiafe](https://www.linkedin.com/in/Izebiafe)
+
+👤 **Evans Kofi Nyamekye**
+- GitHub: [evansnyamekye](https://github.com/evansnyamekye)
+- Twitter: [@nyamekye2131](https://twitter.com/nyamekye2131)
+- LinkedIn: [Evans Kofi Nyamekye](https://www.linkedin.com/in/evans-kofi-nyamekye-1980a4117/)
+
 <!-- FUTURE FEATURES -->
 
 ## 🔭 Future Features <a name="future-features"></a>

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,11 +2,11 @@ class PostsController < ApplicationController
   before_action :set_users, only: %i[index show new]
 
   def index
-    @posts = @user.posts
+    @posts = @user.posts.includes(:comments, :likes)
   end
 
   def show
-    @post = @user.posts.find(params[:id])
+    @post = @user.posts.includes(:comments, :likes).find(params[:id])
   end
 
   def new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,15 +1,16 @@
 class PostsController < ApplicationController
-  before_action :set_users, only: %i[index show new]
-
   def index
+    @user = User.includes(:posts).find(params[:user_id])
     @posts = @user.posts.includes(:comments, :likes)
   end
 
   def show
-    @post = @user.posts.includes(:comments, :likes).find(params[:id])
+    @user = User.includes(posts: :comments).find(params[:user_id])
+    @post = @user.posts.includes(:comments).find(params[:id])
   end
 
   def new
+    @user = User.find(params[:user_id])
     @post = Post.new
   end
 
@@ -30,9 +31,5 @@ class PostsController < ApplicationController
 
   def post_params
     params.require(:post).permit(:title, :text)
-  end
-
-  def set_users
-    @user = User.find(params[:user_id])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,11 @@
 class UsersController < ApplicationController
   def index
-    @users = User.all
+    @users = User.includes(:posts)
   end
+  
 
   def show
-    @user = User.find(params[:id])
+    @user = User.includes(posts: [:comments, :likes]).find(params[:id])
   end
+  
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,6 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.includes(posts: %i[:comments, :likes]).find(params[:id])
+    @user = User.includes(posts: %i[comments likes]).find(params[:id])
   end
-
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,10 +2,9 @@ class UsersController < ApplicationController
   def index
     @users = User.includes(:posts)
   end
-  
 
   def show
-    @user = User.includes(posts: [:comments, :likes]).find(params[:id])
+    @user = User.includes(posts: %i[:comments, :likes]).find(params[:id])
   end
-  
+
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -22,4 +22,5 @@
     </div>
     <% end %> 
     <%= link_to "Pagination", user_posts_path(@user), class: "button" %>
+    <%= link_to "Add New post", new_user_post_path(@user), class: "button" %>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -9,18 +9,19 @@
     </div>
   </div>
 <a href=""></a>
-  <% @posts.limit(2).each_with_index do |post, index| %>
+  <% @posts.limit(2).each do |post| %>
     <div class="post">
-      <h3> <%= link_to "Post", user_post_path(@user, post) %> <%= index+1 %> </h2>
+      <h4>Post</h4>
+      <h4> <%= link_to post.title, user_post_path(@user, post) %> </h4>
       <p><%= post.text %></p>
       <p class='count'>Comments: <%= post.comments.count %> | Likes: <%= post.likes.count %></p>
     </div>
     <div class="comments">
       <% post.recent_comments.each do |comment| %>
-       <p><strong><%= comment.user.name %> :</strong> <%= comment.text %></p>
+       <p><strong><%= comment.author.name %> :</strong> <%= comment.text %></p>
       <% end %>
     </div>
     <% end %> 
-    <%= link_to "Pagination", user_posts_path(@user), class: "button" %>
-    <%= link_to "Add New post", new_user_post_path(@user), class: "button" %>
+    <%= link_to 'Pagination', user_posts_path(@user), class: "button" %>
+    <%= link_to 'Add New post', new_user_post_path(@user), class: 'button' %>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="post">
-    <h4> Post: <%= @post.title %> </h4>
+    <h4><%= @post.title %> by <%= @post.author.name%> </h4>
     <p class='count'>Comments: <%= @post.comments.count %> | Likes: <%= @post.likes.count %></p>
     <p><%= @post.text %></p>
   </div>

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -12,10 +12,10 @@ RSpec.feature 'Post Index View', type: :feature do
     expect(page).to have_content("Number of posts: #{user.posts.count}")
 
     expect(page).to have_selector('.post', count: 1)
-    expect(page).to have_link("Post", href: user_post_path(user, user.posts.first))
+    expect(page).to have_link('Post', href: user_post_path(user, user.posts.first))
     expect(page).to have_content(user.posts.first.text)
-    expect(page).to have_css('.count', text: 'Comments: #{user.posts.first.comments.count}')
-    expect(page).to have_css('.count', text: 'Likes: #{user.posts.first.likes.count}')
+    expect(page).to have_css('.count', text: "Comments: #{user.posts.first.comments.count}")
+    expect(page).to have_css('.count', text: "Likes: #{user.posts.first.likes.count}")
 
     expect(page).to have_selector('.comments', count: 1)
     user.posts.first.recent_comments.each do |comment|

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Post Index View', type: :feature do
   scenario 'User views post index page' do
-    user = User.create(name: 'Austin', photo: 'https://example', bio: 'Integration test user', posts_counter: 0 )
+    user = User.create(name: 'Austin', photo: 'https://example', bio: 'Integration test user', posts_counter: 0)
     post = Post.create(author: user, title: 'Hi', text: 'First Post', comment_counter: 1, like_counter: 3)
 
     visit user_posts_path(user)

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 RSpec.feature 'Post Index View', type: :feature do
   scenario 'User views post index page' do
-    user = User.create(name: 'Austin', photo: 'https://example', bio: 'Intergration test user', posts_counter: 1)
-    Post.create(author: user, title: 'Hi', text: 'First Post', comment_counter: 1, like_counter: 3)
+    user = User.create(name: 'Austin', photo: 'https://example', bio: 'Integration test user', posts_counter: 0 )
+    post = Post.create(author: user, title: 'Hi', text: 'First Post', comment_counter: 1, like_counter: 3)
+
     visit user_posts_path(user)
 
     expect(page).to have_selector('.user_info')
@@ -12,16 +13,17 @@ RSpec.feature 'Post Index View', type: :feature do
     expect(page).to have_content("Number of posts: #{user.posts.count}")
 
     expect(page).to have_selector('.post', count: 1)
-    expect(page).to have_link('Post', href: user_post_path(user, user.posts.first))
-    expect(page).to have_content(user.posts.first.text)
-    expect(page).to have_css('.count', text: "Comments: #{user.posts.first.comments.count}")
-    expect(page).to have_css('.count', text: "Likes: #{user.posts.first.likes.count}")
+    expect(page).to have_content(post.title)
+    expect(page).to have_content(post.text)
+    expect(page).to have_css('.count', text: "Comments: #{post.comments.count}")
+    expect(page).to have_css('.count', text: "Likes: #{post.likes.count}")
 
     expect(page).to have_selector('.comments', count: 1)
-    user.posts.first.recent_comments.each do |comment|
+    post.recent_comments.each do |comment|
       expect(page).to have_content("#{comment.user.name} : #{comment.text}")
     end
 
     expect(page).to have_link('Pagination', href: user_posts_path(user))
+    expect(page).to have_link('Add New post', href: new_user_post_path(user))
   end
 end

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.feature "Post Index View", type: :feature do
+  scenario "User views post index page" do
+    user = User.create(name: 'Austin', photo: 'https://example', bio: 'Intergration test user',
+    posts_counter: 1)
+    Post.create(author: user, title: 'Hi', text: 'First Post', comment_counter: 1, like_counter: 3)
+    
+    visit user_posts_path(user)
+
+    expect(page).to have_selector('.user_info')
+    expect(page).to have_selector('.user-photo')
+    expect(page).to have_content(user.name)
+    expect(page).to have_content("Number of posts: #{user.posts.count}")
+
+    expect(page).to have_selector('.post', count: 1)
+    expect(page).to have_link("Post", href: user_post_path(user, user.posts.first))
+    expect(page).to have_content(user.posts.first.text)
+    expect(page).to have_css('.count', text: "Comments: #{user.posts.first.comments.count}")
+    expect(page).to have_css('.count', text: "Likes: #{user.posts.first.likes.count}")
+
+    expect(page).to have_selector('.comments', count: 1)
+    user.posts.first.recent_comments.each do |comment|
+      expect(page).to have_content("#{comment.user.name} : #{comment.text}")
+    end
+
+    expect(page).to have_link("Pagination", href: user_posts_path(user))
+  end
+end

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -1,11 +1,9 @@
 require 'rails_helper'
 
-RSpec.feature "Post Index View", type: :feature do
-  scenario "User views post index page" do
-    user = User.create(name: 'Austin', photo: 'https://example', bio: 'Intergration test user',
-    posts_counter: 1)
+RSpec.feature 'Post Index View', type: :feature do
+  scenario 'User views post index page' do
+    user = User.create(name: 'Austin', photo: 'https://example', bio: 'Intergration test user', posts_counter: 1)
     Post.create(author: user, title: 'Hi', text: 'First Post', comment_counter: 1, like_counter: 3)
-    
     visit user_posts_path(user)
 
     expect(page).to have_selector('.user_info')
@@ -16,14 +14,14 @@ RSpec.feature "Post Index View", type: :feature do
     expect(page).to have_selector('.post', count: 1)
     expect(page).to have_link("Post", href: user_post_path(user, user.posts.first))
     expect(page).to have_content(user.posts.first.text)
-    expect(page).to have_css('.count', text: "Comments: #{user.posts.first.comments.count}")
-    expect(page).to have_css('.count', text: "Likes: #{user.posts.first.likes.count}")
+    expect(page).to have_css('.count', text: 'Comments: #{user.posts.first.comments.count}')
+    expect(page).to have_css('.count', text: 'Likes: #{user.posts.first.likes.count}')
 
     expect(page).to have_selector('.comments', count: 1)
     user.posts.first.recent_comments.each do |comment|
       expect(page).to have_content("#{comment.user.name} : #{comment.text}")
     end
 
-    expect(page).to have_link("Pagination", href: user_posts_path(user))
+    expect(page).to have_link('Pagination', href: user_posts_path(user))
   end
 end

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.feature "Post Show View", type: :feature do
+  scenario "User views post show page" do
+    user = User.create(name: 'Austin', photo: 'https://example.com', bio: 'Integration test user', posts_counter: 1)
+    post = Post.create(author: user, title: 'Hi', text: 'First Post', comment_counter: 2, like_counter: 3)
+    post.comments.create(user: user, text: 'Great post!')
+    post.comments.create(user: user, text: 'Nice job!')
+
+    visit user_post_path(user, post)
+
+    expect(page).to have_selector('.container')
+    expect(page).to have_selector('.post')
+    expect(page).to have_content("Post: #{post.title}")
+    expect(page).to have_css('.count', text: "Comments: #{post.comments.count}")
+    expect(page).to have_css('.count', text: "Likes: #{post.likes.count}")
+    expect(page).to have_content(post.text)
+
+    expect(page).to have_selector('.comments')
+    post.comments.each do |comment|
+      expect(page).to have_selector('.comment', text: "#{comment.user.name} : #{comment.text}")
+    end
+  end
+end

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -1,19 +1,19 @@
 require 'rails_helper'
 
-RSpec.feature "Post Show View", type: :feature do
-  scenario "User views post show page" do
+RSpec.feature 'Post Show View', type: :feature do
+  scenario 'User views post show page' do
     user = User.create(name: 'Austin', photo: 'https://example.com', bio: 'Integration test user', posts_counter: 1)
     post = Post.create(author: user, title: 'Hi', text: 'First Post', comment_counter: 2, like_counter: 3)
-    post.comments.create(user: user, text: 'Great post!')
-    post.comments.create(user: user, text: 'Nice job!')
+    post.comments.create(user:, text: 'Great post!')
+    post.comments.create(user:, text: 'Nice job!')
 
     visit user_post_path(user, post)
 
     expect(page).to have_selector('.container')
     expect(page).to have_selector('.post')
     expect(page).to have_content("Post: #{post.title}")
-    expect(page).to have_css('.count', text: "Comments: #{post.comments.count}")
-    expect(page).to have_css('.count', text: "Likes: #{post.likes.count}")
+    expect(page).to have_css('.count', text: 'Comments: #{post.comments.count}')
+    expect(page).to have_css('.count', text: 'Likes: #{post.likes.count}')
     expect(page).to have_content(post.text)
 
     expect(page).to have_selector('.comments')

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -12,8 +12,8 @@ RSpec.feature 'Post Show View', type: :feature do
     expect(page).to have_selector('.container')
     expect(page).to have_selector('.post')
     expect(page).to have_content("Post: #{post.title}")
-    expect(page).to have_css('.count', text: 'Comments: #{post.comments.count}')
-    expect(page).to have_css('.count', text: 'Likes: #{post.likes.count}')
+    expect(page).to have_css('.count', text: "Comments: #{post.comments.count}")
+    expect(page).to have_css('.count', text: "Likes: #{post.likes.count}")
     expect(page).to have_content(post.text)
 
     expect(page).to have_selector('.comments')

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Post Show View', type: :feature do
 
     expect(page).to have_selector('.container')
     expect(page).to have_selector('.post')
-    expect(page).to have_content("Post: #{post.title}")
+    expect(page).to have_content("#{post.title} by #{post.author.name}")
     expect(page).to have_css('.count', text: "Comments: #{post.comments.count}")
     expect(page).to have_css('.count', text: "Likes: #{post.likes.count}")
     expect(page).to have_content(post.text)

--- a/spec/features/user_index_spec.rb
+++ b/spec/features/user_index_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+RSpec.feature "Users Index View", type: :feature do
+  scenario "User views users index page" do
+    user1 = User.create(name: 'Alice', photo: 'https://example.com/alice.jpg')
+    user1.posts.create(title: 'Post 1', text: 'First post by Alice')
+    user1.posts.create(title: 'Post 2', text: 'Second post by Alice')
+    user2 = User.create(name: 'Bob', photo: 'https://example.com/bob.jpg')
+    user2.posts.create(title: 'Post 3', text: 'First post by Bob')
+    visit users_path
+    expect(page).to have_selector('.container')
+    expect(page).to have_selector('.user_info', count: 4)
+    expect(page).to have_css('.user-photo', count: 4)
+    expect(page).to have_link('Alice', href: user_path(user1))
+    expect(page).to have_link('Bob', href: user_path(user2))
+    within('.user_info', text: 'Alice') do
+      expect(page).to have_content("Number of posts: #{user1.posts.count}")
+    end
+    within('.user_info', text: 'Bob') do
+      expect(page).to have_content("Number of posts: #{user2.posts.count}")
+    end
+  end
+end

--- a/spec/features/user_index_spec.rb
+++ b/spec/features/user_index_spec.rb
@@ -13,10 +13,10 @@ RSpec.feature 'Users Index View', type: :feature do
     expect(page).to have_link('Alice', href: user_path(user1))
     expect(page).to have_link('Bob', href: user_path(user2))
     within('.user_info', text: 'Alice') do
-      expect(page).to have_content('Number of posts: #{user1.posts.count}')
+      expect(page).to have_content("Number of posts: #{user1.posts.count}")
     end
     within('.user_info', text: 'Bob') do
-      expect(page).to have_content('Number of posts: #{user2.posts.count}')
+      expect(page).to have_content("Number of posts: #{user2.posts.count}")
     end
   end
 end

--- a/spec/features/user_index_spec.rb
+++ b/spec/features/user_index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
-RSpec.feature "Users Index View", type: :feature do
-  scenario "User views users index page" do
+RSpec.feature 'Users Index View', type: :feature do
+  scenario 'User views users index page' do
     user1 = User.create(name: 'Alice', photo: 'https://example.com/alice.jpg')
     user1.posts.create(title: 'Post 1', text: 'First post by Alice')
     user1.posts.create(title: 'Post 2', text: 'Second post by Alice')
@@ -13,10 +13,10 @@ RSpec.feature "Users Index View", type: :feature do
     expect(page).to have_link('Alice', href: user_path(user1))
     expect(page).to have_link('Bob', href: user_path(user2))
     within('.user_info', text: 'Alice') do
-      expect(page).to have_content("Number of posts: #{user1.posts.count}")
+      expect(page).to have_content('Number of posts: #{user1.posts.count}')
     end
     within('.user_info', text: 'Bob') do
-      expect(page).to have_content("Number of posts: #{user2.posts.count}")
+      expect(page).to have_content('Number of posts: #{user2.posts.count}')
     end
   end
 end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.feature "User Show View", type: :feature do
+  scenario "User views user show page" do
+    # Create a user with associated posts
+    user = User.create(name: 'Alice', photo: 'https://example.com/alice.jpg', bio: 'Test bio')
+    post1 = user.posts.create(title: 'Post 1', text: 'First post by Alice', comment_counter: 2, like_counter: 3)
+    post2 = user.posts.create(title: 'Post 2', text: 'Second post by Alice', comment_counter: 1, like_counter: 1)
+
+    visit user_path(user)
+
+    expect(page).to have_selector('.container')
+    expect(page).to have_selector('.user_info')
+    expect(page).to have_selector('.user_bio')
+    expect(page).to have_css('.user-photo')
+    expect(page).to have_content(user.name)
+    expect(page).to have_content("Number of posts: #{user.posts.count}")
+    expect(page).to have_content(user.bio)
+
+    expect(page).to have_selector('.post', count: 2) 
+    expect(page).to have_link('Post', href: user_post_path(user, post1))
+    expect(page).to have_link('Post', href: user_post_path(user, post2))
+    expect(page).to have_content(post1.title)
+    expect(page).to have_content(post2.title)
+    expect(page).to have_css('.count', text: "Comments: #{post1.comments.count} | Likes: #{post1.likes.count}")
+    expect(page).to have_css('.count', text: "Comments: #{post2.comments.count} | Likes: #{post2.likes.count}")
+
+    expect(page).to have_link('See all posts', href: user_posts_path(user))
+  end
+end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.feature 'User Show View', type: :feature do
-  scenario 'User views user show page' do
-    # Create a user with associated posts
+  scenario 'User views user show page with three recent posts' do
     user = User.create(name: 'Alice', photo: 'https://example.com/alice.jpg', bio: 'Test bio')
     post1 = user.posts.create(title: 'Post 1', text: 'First post by Alice', comment_counter: 2, like_counter: 3)
     post2 = user.posts.create(title: 'Post 2', text: 'Second post by Alice', comment_counter: 1, like_counter: 1)
+    post3 = user.posts.create(title: 'Post 3', text: 'Third post by Alice', comment_counter: 1, like_counter: 1)
 
     visit user_path(user)
 
@@ -17,13 +17,16 @@ RSpec.feature 'User Show View', type: :feature do
     expect(page).to have_content("Number of posts: #{user.posts.count}")
     expect(page).to have_content(user.bio)
 
-    expect(page).to have_selector('.post', count: 2)
+    expect(page).to have_selector('.post', count: 3)
     expect(page).to have_link('Post', href: user_post_path(user, post1))
     expect(page).to have_link('Post', href: user_post_path(user, post2))
+    expect(page).to have_link('Post', href: user_post_path(user, post3))
     expect(page).to have_content(post1.title)
     expect(page).to have_content(post2.title)
+    expect(page).to have_content(post3.title)
     expect(page).to have_css('.count', text: "Comments: #{post1.comments.count} | Likes: #{post1.likes.count}")
     expect(page).to have_css('.count', text: "Comments: #{post2.comments.count} | Likes: #{post2.likes.count}")
+    expect(page).to have_css('.count', text: "Comments: #{post3.comments.count} | Likes: #{post3.likes.count}")
 
     expect(page).to have_link('See all posts', href: user_posts_path(user))
   end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.feature "User Show View", type: :feature do
-  scenario "User views user show page" do
+RSpec.feature 'User Show View', type: :feature do
+  scenario 'User views user show page' do
     # Create a user with associated posts
     user = User.create(name: 'Alice', photo: 'https://example.com/alice.jpg', bio: 'Test bio')
     post1 = user.posts.create(title: 'Post 1', text: 'First post by Alice', comment_counter: 2, like_counter: 3)
@@ -22,8 +22,8 @@ RSpec.feature "User Show View", type: :feature do
     expect(page).to have_link('Post', href: user_post_path(user, post2))
     expect(page).to have_content(post1.title)
     expect(page).to have_content(post2.title)
-    expect(page).to have_css('.count', text: "Comments: #{post1.comments.count} | Likes: #{post1.likes.count}")
-    expect(page).to have_css('.count', text: "Comments: #{post2.comments.count} | Likes: #{post2.likes.count}")
+    expect(page).to have_css('.count', text: 'Comments: #{post1.comments.count} | Likes: #{post1.likes.count}')
+    expect(page).to have_css('.count', text: 'Comments: #{post2.comments.count} | Likes: #{post2.likes.count}')
 
     expect(page).to have_link('See all posts', href: user_posts_path(user))
   end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -17,13 +17,13 @@ RSpec.feature 'User Show View', type: :feature do
     expect(page).to have_content("Number of posts: #{user.posts.count}")
     expect(page).to have_content(user.bio)
 
-    expect(page).to have_selector('.post', count: 2) 
+    expect(page).to have_selector('.post', count: 2)
     expect(page).to have_link('Post', href: user_post_path(user, post1))
     expect(page).to have_link('Post', href: user_post_path(user, post2))
     expect(page).to have_content(post1.title)
     expect(page).to have_content(post2.title)
-    expect(page).to have_css('.count', text: 'Comments: #{post1.comments.count} | Likes: #{post1.likes.count}')
-    expect(page).to have_css('.count', text: 'Comments: #{post2.comments.count} | Likes: #{post2.likes.count}')
+    expect(page).to have_css('.count', text: "Comments: #{post1.comments.count} | Likes: #{post1.likes.count}")
+    expect(page).to have_css('.count', text: "Comments: #{post2.comments.count} | Likes: #{post2.likes.count}")
 
     expect(page).to have_link('See all posts', href: user_posts_path(user))
   end


### PR DESCRIPTION
- Made sure that the N+1 problem is solved when fetching all posts and their comments for a user.
Here are the logs before:
![image](https://github.com/Obimbo07/tdn/assets/118368849/e01f31c7-3132-4ec0-845e-0868ad589a5d)
Here are the logs: 
![image](https://github.com/Obimbo07/tdn/assets/118368849/1048f826-c99e-4746-a26d-3b77bb696a09)

- Used Capybara to write integration tests for each view.

- [ ] User index page:

I can see the username of all other users.
I can see the profile picture for each user.
I can see the number of posts each user has written.
When I click on a user, I am redirected to that user's show page.

- [ ] User show page:

I can see the user's profile picture.
I can see the user's username.
I can see the number of posts the user has written.
I can see the user's bio.
I can see the user's first 3 posts.
I can see a button that lets me view a user's posts.
When I click a user's post, it redirects me to that post's show page.
When I click to see all posts, it redirects me to the user's post's index page.

- [ ] User post index page:

I can see the user's profile picture.
I can see the user's username.
I can see the number of posts the user has written.
I can see a post's title.
I can see some of the post's body.
I can see the first comments on a post.
I can see how many comments a post has.
I can see how many likes a post has.
I can see a section for pagination if there are more posts than fit on the view.
When I click on a post, it redirects me to that post's show page.

- [ ] Post show page:

I can see the post's title.
I can see who wrote the post.
I can see how many comments it has.
I can see how many likes it has.
I can see the post body.
I can see the username of each commentor.
I can see the comment each commentor left.